### PR TITLE
pytest-aiomoto fixtures and plugin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # pytest-aiomoto
 
-[![Build Status](https://travis-ci.com/dazza-codes/pytest-aiomoto.svg?branch=main)](https://travis-ci.com/dazza-codes/pytest-aiomoto)
 [![Documentation Status](https://readthedocs.org/projects/pytest-aiomoto/badge/?version=latest)](https://pytest-aiomoto.readthedocs.io/en/latest/?badge=latest)
 
 [![PyPI version](https://img.shields.io/pypi/v/pytest-aiomoto.svg)](https://pypi.org/project/pytest-aiomoto)
 [![Python versions](https://img.shields.io/pypi/pyversions/pytest-aiomoto.svg)](https://pypi.org/project/pytest-aiomoto)
 
 [pytest](https://docs.pytest.org) fixtures for AWS services,
-with support for asyncio fixtures using [aiobotocore](https://aiobotocore.readthedocs.io)
+with support for asyncio fixtures using
+[aiobotocore](https://aiobotocore.readthedocs.io)
+
+## Warning
+
+- This package is work in progress, it is not recommended for production purposes.
+  During the initial phases of this project, it is likely that some releases
+  could introduce breaking changes in test fixtures.  It's highly
+  recommended pinning this dependency to patch releases during the
+  0.x.y releases.
+- This package could restrict available versions of aws libs, including:
+  aiobotocore, botocore, boto3, and moto.  The initial intention is to allow
+  any 2.x.y versions of aiobotocore and moto.
+- The fixtures in this package might not be optimized for concurrent testing.
+  It is not known yet whether the fixtures are thread safe or adequately
+  randomized to support parallel test suites.
 
 ## Installation
 
@@ -21,11 +35,39 @@ To list the available fixtures
 
     $ pytest --fixtures
 
+This project attempts to provide some common fixtures for commonly used
+services.  As such, it is not a generic package for any services; the
+moto project provides that and this project builds on that.  This
+project aims to create some useful fixtures that behave nearly the
+same way for both synchronous clients (botocore) and
+asynchronous clients (aiobotocore).
+
 ## Contributing
 
-Contributions are very welcome. Tests can be run with
-[pytest](https://github.com/pytest-dev/pytest), please ensure
-the coverage at least stays the same before you submit a pull request.
+Contributions are welcome, if you build similar common fixtures or build
+on the existing package fixtures.  The details for bug fixes could be
+complicated, due to the dependencies on aiobotocore and moto.
+
+Please review [github collaboration](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
+practices.  Once you clone your fork of the repository:
+
+    cd pytest-aiomoto
+    make init
+    make test
+
+It's recommended that development use python 3.7, to avoid introducing any python
+code that might not be compatible with the minimum version of python supported.  This
+is important in the context of the general evolution of asyncio in python.
+
+Most development is done in a linux context (e.g. Ubuntu LTS).  If some development
+tools or common practices are not working as expected on OSX or Windows, there is
+limited support for adapting to various development environments.
+
+Tests are run with [pytest](https://github.com/pytest-dev/pytest), please ensure
+the percentage of coverage at least stays the same before you submit a pull request.
+The expectation for contributions might be a slow process, please do not anticipate
+any turn around on the order of days (unless you're already a core contributor).
+Using your own fork can be a faster way to evolve your fixtures for your use cases.
 
 ## Issues
 

--- a/docs/aiomoto_fixtures.md
+++ b/docs/aiomoto_fixtures.md
@@ -1,0 +1,3 @@
+# AioMoto Fixtures
+
+::: pytest_aiomoto.aiomoto_fixtures

--- a/poetry.lock
+++ b/poetry.lock
@@ -2380,7 +2380,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b93069fcf9ae7ff77989a40a647b2e6bb45af012aa7b515d9fb6b4ce5d3fbf86"
+content-hash = "5f57da12c723466931578864feaa2d21c381d86548031febb81f644abe58e8c8"
 
 [metadata.files]
 aiobotocore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 
 [tool.poetry.plugins]
 [tool.poetry.plugins."pytest11"]
-"aiomoto" = "pytest_aiomoto"
+"aiomoto" = "pytest_aiomoto.plugin"
 
 
 [tool.poetry.dependencies]
@@ -48,7 +48,7 @@ pytest = "^6.2.5"
 pytest-asyncio = "^0.14.0"
 
 # Try to update to the latest aiobotocore
-aiobotocore = {version = "~2.0.0", extras = ["boto3"]}
+aiobotocore = {version = "^2.0.0", extras = ["boto3"]}
 moto = {version = "^2.0.0", extras = ["all","server"]}
 
 aiofiles = {version = "^0.7.0"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,3 @@ log_date_format = %Y-%m-%d %H:%M:%S
 filterwarnings =
     ignore:.*botocore.*:DeprecationWarning
 
-markers =
-    s3_live: tests that require credentials for live S3 network requests

--- a/pytest_aiomoto/aiomoto_fixtures.py
+++ b/pytest_aiomoto/aiomoto_fixtures.py
@@ -1,0 +1,390 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AWS test fixtures
+
+This test suite uses a large suite of moto mocks for the AWS batch
+infrastructure. These infrastructure mocks are derived from the moto test
+suite for testing the batch client. The test infrastructure should be used
+according to the moto license. That license overrides any global license
+applied to my aio_aws project.
+
+.. seealso::
+
+    - https://github.com/spulec/moto/pull/1197/files
+    - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+"""
+
+from typing import NamedTuple
+from typing import Optional
+
+import pytest
+from aiobotocore.client import AioBaseClient
+from aiobotocore.config import AioConfig
+from aiobotocore.session import get_session
+
+from pytest_aiomoto.aiomoto_services import MotoService
+from pytest_aiomoto.utils import AWS_ACCESS_KEY_ID
+from pytest_aiomoto.utils import AWS_REGION
+from pytest_aiomoto.utils import AWS_SECRET_ACCESS_KEY
+
+
+@pytest.fixture
+async def aio_aws_batch_server():
+    async with MotoService("batch") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_cloudformation_server():
+    async with MotoService("cloudformation") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_ec2_server():
+    async with MotoService("ec2") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_ecs_server():
+    async with MotoService("ecs") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_iam_server():
+    async with MotoService("iam") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_dynamodb2_server():
+    async with MotoService("dynamodb2") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_lambda_server():
+    async with MotoService("lambda") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_logs_server():
+    # cloud watch logs
+    async with MotoService("logs") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_s3_server():
+    async with MotoService("s3") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_sns_server():
+    async with MotoService("sns") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+async def aio_aws_sqs_server():
+    async with MotoService("sqs") as svc:
+        svc.reset()
+        yield svc.endpoint_url
+        svc.reset()
+
+
+@pytest.fixture
+def aio_aws_session(aws_credentials, aws_region, event_loop):
+    # pytest-asyncio provides and manages the `event_loop`
+    # and it should be set as the default loop for this session
+    assert event_loop  # but it's not == asyncio.get_event_loop() ?
+
+    session = get_session()
+    session.user_agent_name = "aiomoto"
+
+    assert session.get_default_client_config() is None
+    aioconfig = AioConfig(max_pool_connections=1, region_name=aws_region)
+
+    # Note: tried to use proxies for the aiobotocore.endpoint, to replace
+    #      'https://batch.us-west-2.amazonaws.com/v1/describejobqueues', but
+    #      the moto.server does not behave as a proxy server.  Leaving this
+    #      here for the record to avoid trying to do it again sometime later.
+    # proxies = {
+    #     'http': os.getenv("HTTP_PROXY", "http://127.0.0.1:5000/moto-api/"),
+    #     'https': os.getenv("HTTPS_PROXY", "http://127.0.0.1:5000/moto-api/"),
+    # }
+    # assert aioconfig.proxies is None
+    # aioconfig.proxies = proxies
+
+    session.set_default_client_config(aioconfig)
+    assert session.get_default_client_config() == aioconfig
+
+    session.set_credentials(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+    session.set_debug_logger(logger_name="aiomoto")
+
+    yield session
+
+
+@pytest.fixture
+def aio_aws_client(aio_aws_session):
+    async def _get_client(service_name):
+        async with MotoService(service_name) as srv:
+            async with aio_aws_session.create_client(
+                service_name, endpoint_url=srv.endpoint_url
+            ) as client:
+                yield client
+
+    return _get_client
+
+
+@pytest.fixture
+async def aio_aws_batch_client(aio_aws_session, aio_aws_batch_server):
+    async with aio_aws_session.create_client(
+        "batch", endpoint_url=aio_aws_batch_server
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_ec2_client(aio_aws_session, aio_aws_ec2_server):
+    async with aio_aws_session.create_client(
+        "ec2", endpoint_url=aio_aws_ec2_server
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_ecs_client(aio_aws_session, aio_aws_ecs_server):
+    async with aio_aws_session.create_client(
+        "ecs", endpoint_url=aio_aws_ecs_server
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_iam_client(aio_aws_session, aio_aws_iam_server):
+    async with aio_aws_session.create_client(
+        "iam", endpoint_url=aio_aws_iam_server
+    ) as client:
+        client.meta.config.region_name = "aws-global"  # not AWS_REGION
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_lambda_client(aio_aws_session, aio_aws_lambda_server):
+    async with aio_aws_session.create_client(
+        "lambda", endpoint_url=aio_aws_lambda_server
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_logs_client(aio_aws_session, aio_aws_logs_server):
+    async with aio_aws_session.create_client(
+        "logs", endpoint_url=aio_aws_logs_server
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def aio_aws_s3_client(aio_aws_session, aio_aws_s3_server, mocker):
+    async with aio_aws_session.create_client(
+        "s3", endpoint_url=aio_aws_s3_server
+    ) as client:
+        # TODO: find a way to apply this method mock only for creating "s3" clients;
+        # # ensure the session returns the mock s3 client
+        # mocker.patch.object(
+        #     aiobotocore.session.AioClientCreator, "create_client",
+        #     return_value=client
+        # )
+        yield client
+
+
+class AioBatchClient(AioBaseClient):
+    pass
+
+
+class AioEC2Client(AioBaseClient):
+    pass
+
+
+class AioECSClient(AioBaseClient):
+    pass
+
+
+class AioIAMClient(AioBaseClient):
+    pass
+
+
+class AioCloudWatchLogsClient(AioBaseClient):
+    pass
+
+
+class AioAwsBatchClients(NamedTuple):
+    batch: AioBatchClient
+    ec2: AioEC2Client
+    ecs: AioECSClient
+    iam: AioIAMClient
+    logs: AioCloudWatchLogsClient
+    region: str
+
+
+@pytest.fixture
+async def aio_aws_batch_clients(
+    aio_aws_batch_client,
+    aio_aws_ec2_client,
+    aio_aws_ecs_client,
+    aio_aws_iam_client,
+    aio_aws_logs_client,
+    aws_region,
+):
+    return AioAwsBatchClients(
+        batch=aio_aws_batch_client,
+        ec2=aio_aws_ec2_client,
+        ecs=aio_aws_ecs_client,
+        iam=aio_aws_iam_client,
+        logs=aio_aws_logs_client,
+        region=aws_region,
+    )
+
+
+class AioAwsBatchInfrastructure:
+    aio_aws_clients: AioAwsBatchClients
+    aws_region: str = AWS_REGION
+    vpc_id: Optional[str] = None
+    subnet_id: Optional[str] = None
+    security_group_id: Optional[str] = None
+    iam_arn: Optional[str] = None
+    compute_env_name: Optional[str] = None
+    compute_env_arn: Optional[str] = None
+    job_queue_name: Optional[str] = None
+    job_queue_arn: Optional[str] = None
+    job_definition_name: Optional[str] = None
+    job_definition_arn: Optional[str] = None
+
+
+async def aio_batch_infrastructure(
+    aio_aws_batch_clients: AioAwsBatchClients,
+    aws_region: str,
+    compute_env_name: str,
+    job_queue_name: str,
+    job_definition_name: str,
+) -> AioAwsBatchInfrastructure:
+    """
+    Create AWS Batch infrastructure, including:
+    - VPC with subnet
+    - Security group and IAM role
+    - Batch compute environment and job queue
+    - Batch job job_definition
+
+    This function is not a fixture so that tests can pass the AWS clients to it and then
+    continue to use the infrastructure created by it while the client fixtures are in-tact for
+    the duration of a test.
+    """
+
+    infrastructure = AioAwsBatchInfrastructure()
+    infrastructure.aws_region = aws_region
+    infrastructure.aio_aws_clients = aio_aws_batch_clients
+
+    resp = await aio_aws_batch_clients.ec2.create_vpc(CidrBlock="172.30.0.0/24")
+    vpc_id = resp["Vpc"]["VpcId"]
+
+    resp = await aio_aws_batch_clients.ec2.create_subnet(
+        AvailabilityZone=f"{aws_region}a", CidrBlock="172.30.0.0/25", VpcId=vpc_id
+    )
+    subnet_id = resp["Subnet"]["SubnetId"]
+
+    resp = await aio_aws_batch_clients.ec2.create_security_group(
+        Description="moto_test_sg_desc", GroupName="moto_test_sg", VpcId=vpc_id
+    )
+    sg_id = resp["GroupId"]
+
+    resp = await aio_aws_batch_clients.iam.create_role(
+        RoleName="MotoTestRole", AssumeRolePolicyDocument="moto_test_policy"
+    )
+    iam_arn = resp["Role"]["Arn"]
+
+    resp = await aio_aws_batch_clients.batch.create_compute_environment(
+        computeEnvironmentName=compute_env_name,
+        type="UNMANAGED",
+        state="ENABLED",
+        serviceRole=iam_arn,
+    )
+    compute_env_arn = resp["computeEnvironmentArn"]
+
+    resp = await aio_aws_batch_clients.batch.create_job_queue(
+        jobQueueName=job_queue_name,
+        state="ENABLED",
+        priority=123,
+        computeEnvironmentOrder=[{"order": 123, "computeEnvironment": compute_env_arn}],
+    )
+    assert resp["jobQueueName"] == job_queue_name
+    assert resp["jobQueueArn"]
+    job_queue_arn = resp["jobQueueArn"]
+
+    resp = await aio_aws_batch_clients.batch.register_job_definition(
+        jobDefinitionName=job_definition_name,
+        type="container",
+        containerProperties={
+            "image": "alpine",
+            "vcpus": 1,
+            "memory": 8,
+            "command": ["sleep", "5"],  # NOTE: job runs for 5 sec without overrides
+        },
+    )
+    assert resp["jobDefinitionName"] == job_definition_name
+    assert resp["jobDefinitionArn"]
+    job_definition_arn = resp["jobDefinitionArn"]
+    assert resp["revision"]
+    assert resp["jobDefinitionArn"].endswith(
+        "{0}:{1}".format(resp["jobDefinitionName"], resp["revision"])
+    )
+
+    infrastructure.vpc_id = vpc_id
+    infrastructure.subnet_id = subnet_id
+    infrastructure.security_group_id = sg_id
+    infrastructure.iam_arn = iam_arn
+    infrastructure.compute_env_name = compute_env_name
+    infrastructure.compute_env_arn = compute_env_arn
+    infrastructure.job_queue_name = job_queue_name
+    infrastructure.job_queue_arn = job_queue_arn
+    infrastructure.job_definition_name = job_definition_name
+    infrastructure.job_definition_arn = job_definition_arn
+    return infrastructure

--- a/pytest_aiomoto/aiomoto_lambda.py
+++ b/pytest_aiomoto/aiomoto_lambda.py
@@ -1,0 +1,68 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Asyncio AWS Lambda
+
+"""
+
+import botocore.client
+import botocore.exceptions
+import pytest
+
+from pytest_aiomoto.aws_lambda import aws_lambda_src
+from pytest_aiomoto.aws_lambda import zip_lambda
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.fixture
+def aws_lambda_zip() -> bytes:
+    return zip_lambda(aws_lambda_src())
+
+
+@pytest.fixture
+async def lambda_iam_role(aio_aws_iam_client):
+    try:
+        response = await aio_aws_iam_client.get_role(RoleName="my-role")
+        return response["Role"]["Arn"]
+    except botocore.client.ClientError:
+        response = await aio_aws_iam_client.create_role(
+            RoleName="my-role",
+            AssumeRolePolicyDocument="some policy",
+            Path="/my-path/",
+        )
+        return response["Role"]["Arn"]
+
+
+@pytest.fixture
+async def aws_lambda_func(
+    aws_lambda_zip, lambda_iam_role, aio_aws_lambda_client
+) -> str:
+
+    func = "lambda_dev"
+
+    response = await aio_aws_lambda_client.create_function(
+        FunctionName=func,
+        Runtime="python3.7",
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": aws_lambda_zip},
+        Role=lambda_iam_role,
+        Description="lambda_dev function",
+        Timeout=10,
+        MemorySize=128,
+        Publish=True,
+    )
+    assert response_success(response)
+
+    return func

--- a/pytest_aiomoto/aiomoto_s3.py
+++ b/pytest_aiomoto/aiomoto_s3.py
@@ -1,0 +1,125 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import pytest
+
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.fixture
+def aio_s3_bucket_name() -> str:
+    """A valid S3 bucket name
+    :return: str for the bucket component of 's3://{bucket}/{key}'
+    """
+    # TODO: use a random UUID for a bucket name
+    return "aio-moto-bucket"
+
+
+@pytest.fixture
+def aio_s3_key_path() -> str:
+    """A valid S3 key name that is not a file name, it's like a directory
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_path}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return "aio_s3_key_path"
+
+
+@pytest.fixture
+def aio_s3_key_file() -> str:
+    """A valid S3 key name that is also a file name
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_file}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return "aio_s3_file_test.txt"
+
+
+@pytest.fixture
+def aio_s3_key(aio_s3_key_path, aio_s3_key_file) -> str:
+    """A valid S3 key composed of a key_path and a key_file
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_path}/{key_file}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return f"{aio_s3_key_path}/{aio_s3_key_file}"
+
+
+@pytest.fixture
+def aio_s3_uri(aio_s3_bucket_name, aio_s3_key) -> str:
+    """A valid S3 URI comprised of 's3://{bucket}/{key}'
+    :return: str
+    """
+    return f"s3://{aio_s3_bucket_name}/{aio_s3_key}"
+
+
+@pytest.fixture
+def aio_s3_object_text() -> str:
+    """s3 object data: 's3 test object text\n'"""
+    return "aio-s3 test object text\n"
+
+
+@pytest.fixture
+async def aio_s3_bucket(aio_s3_bucket_name, aio_s3_key, aio_aws_s3_client, aws_region) -> str:
+    resp = await aio_aws_s3_client.create_bucket(
+        Bucket=aio_s3_bucket_name,
+        ACL="public-read-write",
+        CreateBucketConfiguration={"LocationConstraint": aws_region},
+    )
+    assert response_success(resp)
+    head = await aio_aws_s3_client.head_bucket(Bucket=aio_s3_bucket_name)
+    assert response_success(head)
+
+    yield aio_s3_bucket_name
+    # TODO: cleanup bucket
+
+
+@pytest.fixture
+async def aio_s3_buckets(
+    aio_s3_bucket_name, aio_aws_s3_client, aws_region
+) -> List[str]:
+    bucket_names = []
+    for i in range(20):
+        bucket_name = f"{aio_s3_bucket_name}_{i:02d}"
+        resp = await aio_aws_s3_client.create_bucket(
+            Bucket=bucket_name,
+            ACL="public-read-write",
+            CreateBucketConfiguration={"LocationConstraint": aws_region},
+        )
+        assert response_success(resp)
+        head = await aio_aws_s3_client.head_bucket(Bucket=bucket_name)
+        assert response_success(head)
+        bucket_names.append(bucket_name)
+
+    return bucket_names
+
+
+@pytest.fixture
+async def aio_s3_object_uri(
+    aio_s3_bucket_name, aio_s3_key, aio_s3_uri, aio_s3_object_text, aio_s3_bucket, aio_aws_s3_client
+) -> str:
+    """s3 object data is PUT to the aio_s3_uri"""
+    resp = await aio_aws_s3_client.put_object(
+        Bucket=aio_s3_bucket_name,
+        Key=aio_s3_key,
+        Body=aio_s3_object_text,
+        ACL="public-read-write",
+    )
+    assert response_success(resp)
+    resp = await aio_aws_s3_client.head_object(Bucket=aio_s3_bucket_name, Key=aio_s3_key)
+    assert response_success(resp)
+
+    return aio_s3_uri

--- a/pytest_aiomoto/aiomoto_services.py
+++ b/pytest_aiomoto/aiomoto_services.py
@@ -1,0 +1,152 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import logging
+import os
+import threading
+import time
+
+import aiohttp
+import moto.server
+import werkzeug.serving
+
+from pytest_aiomoto.utils import AWS_HOST
+from pytest_aiomoto.utils import get_free_tcp_port
+
+_PYCHARM_HOSTED = os.environ.get("PYCHARM_HOSTED") == "1"
+CONNECT_TIMEOUT = 90 if _PYCHARM_HOSTED else 10
+
+
+def moto_service_reset(service_name: str):
+    # each service can have multiple regional backends
+    service_backends = moto.server.backends.get_backend(service_name)
+    for region_name, backend in service_backends.items():
+        backend.reset()
+
+
+class MotoService:
+    """Will Create MotoService.
+    Service is ref-counted so there will only be one per process. Real Service will
+    be returned by `__aenter__`."""
+
+    _services = dict()  # {name: instance}
+
+    def __init__(self, service_name: str, port: int = None):
+        self._service_name = service_name
+
+        if port:
+            self._socket = None
+            self._port = port
+        else:
+            self._socket, self._port = get_free_tcp_port()
+
+        self._thread = None
+        self._logger = logging.getLogger("MotoService")
+        self._refcount = 0
+        self._ip_address = AWS_HOST
+        self._server = None
+
+    @property
+    def endpoint_url(self):
+        return "http://{}:{}".format(self._ip_address, self._port)
+
+    def reset(self):
+        # each service can have multiple regional backends
+        service_backends = moto.server.backends.get_backend(self._service_name)
+        for region_name, backend in service_backends.items():
+            backend.reset()
+
+    def __call__(self, func):
+        async def wrapper(*args, **kwargs):
+            await self._start()
+            try:
+                result = await func(*args, **kwargs)
+            finally:
+                await self._stop()
+            return result
+
+        functools.update_wrapper(wrapper, func)
+        wrapper.__wrapped__ = func
+        return wrapper
+
+    async def __aenter__(self):
+        svc = self._services.get(self._service_name)
+        if svc is None:
+            self._services[self._service_name] = self
+            self._refcount = 1
+            await self._start()
+            return self
+        else:
+            svc._refcount += 1
+            return svc
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._refcount -= 1
+
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+
+        if self._refcount == 0:
+            del self._services[self._service_name]
+            await self._stop()
+
+    def _server_entry(self):
+        self._main_app = moto.server.DomainDispatcherApplication(
+            moto.server.create_backend_app, service=self._service_name
+        )
+        self._main_app.debug = True
+
+        if self._socket:
+            self._socket.close()  # release right before we use it
+            self._socket = None
+
+        self._server = werkzeug.serving.make_server(
+            self._ip_address, self._port, self._main_app, True
+        )
+        self._server.serve_forever()
+
+    async def _start(self):
+        self._thread = threading.Thread(target=self._server_entry, daemon=True)
+        self._thread.start()
+
+        async with aiohttp.ClientSession() as session:
+            start = time.time()
+
+            while time.time() - start < 10:
+                if not self._thread.is_alive():
+                    break
+
+                try:
+                    # we need to bypass the proxies due to monkeypatches
+                    async with session.get(
+                        self.endpoint_url + "/static", timeout=CONNECT_TIMEOUT
+                    ):
+                        pass
+                    break
+                except (asyncio.TimeoutError, aiohttp.ClientConnectionError):
+                    await asyncio.sleep(0.2)
+            else:
+                await self._stop()  # pytest.fail doesn't call stop_process
+                raise Exception(
+                    "Cannot start MotoService: {}".format(self._service_name)
+                )
+
+    async def _stop(self):
+        if self._server:
+            self._server.shutdown()
+
+        self._thread.join()

--- a/pytest_aiomoto/aws_batch_models.py
+++ b/pytest_aiomoto/aws_batch_models.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AWS Batch Utilities
+===================
+
+"""
+
+import enum
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Dict
+from typing import List
+from typing import Union
+
+
+def gb_to_mib(gb: Union[int, float]) -> float:
+    """
+    Gigabyte (Gb) to Mebibyte (MiB)
+    :param gb: Gigabytes (Gb)
+    :return: Mebibytes (MiB)
+    """
+    return gb * 953.674
+
+
+def gb_to_gib(gb: Union[int, float]) -> float:
+    """
+    Gigabyte (Gb) to Gibibyte (GiB)
+    :param gb: Gigabytes (Gb)
+    :return: Gibibyte (GiB)
+    """
+    return gb * 1.07374
+
+
+def gib_to_mib(gib: Union[int, float]) -> float:
+    """
+    Gibibyte (GiB) to Mebibytes (GiB)
+    :param gib: Gibibyte (GiB)
+    :return: Mebibytes (MiB)
+    """
+    return gib * 1024.0
+
+
+@total_ordering
+class AWSBatchJobStates(enum.Enum):
+    SUBMITTED = 1
+    PENDING = 2
+    RUNNABLE = 3
+    STARTING = 4
+    RUNNING = 5
+    SUCCEEDED = 6
+    FAILED = 7
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+
+@dataclass
+class AWSBatchJobDescription:
+    jobName: str = None
+    jobId: str = None
+    jobQueue: str = None
+    status: str = None
+    attempts: List[Dict] = None
+    statusReason: str = None
+    createdAt: int = None
+    startedAt: int = None
+    stoppedAt: int = None
+    dependsOn: List[str] = None
+    jobDefinition: str = None
+    parameters: Dict = None
+    container: Dict = None
+    timeout: Dict = None

--- a/pytest_aiomoto/aws_fixtures.py
+++ b/pytest_aiomoto/aws_fixtures.py
@@ -1,0 +1,679 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AWS test fixtures
+
+This test suite uses a large suite of moto mocks for the AWS batch
+infrastructure. These infrastructure mocks are derived from the moto test
+suite for testing the batch client. The test infrastructure should be used
+according to the moto license.
+
+.. seealso::
+
+    - https://github.com/spulec/moto/pull/1197/files
+    - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+"""
+import os
+import uuid
+from itertools import chain
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+
+import boto3
+import botocore.waiter
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_batch
+from moto import mock_ec2
+from moto import mock_ecs
+from moto import mock_iam
+from moto import mock_logs
+from moto import mock_s3
+
+from pytest_aiomoto.s3_object import S3Object
+from pytest_aiomoto.utils import AWS_ACCESS_KEY_ID
+from pytest_aiomoto.utils import AWS_HOST
+from pytest_aiomoto.utils import AWS_PORT
+from pytest_aiomoto.utils import AWS_REGION
+from pytest_aiomoto.utils import AWS_SECRET_ACCESS_KEY
+from pytest_aiomoto.utils import assert_status_code
+from pytest_aiomoto.utils import has_moto_mocks
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.fixture
+def aws_host(monkeypatch):
+    host = os.getenv("AWS_HOST", AWS_HOST)
+    monkeypatch.setenv("AWS_HOST", host)
+    yield
+
+
+@pytest.fixture
+def aws_port(monkeypatch):
+    port = os.getenv("AWS_PORT", AWS_PORT)
+    monkeypatch.setenv("AWS_PORT", port)
+    yield
+
+
+@pytest.fixture
+def aws_proxy(aws_host, aws_port, monkeypatch):
+    # only required if using a moto stand-alone server or similar local stack
+    monkeypatch.setenv("HTTP_PROXY", f"http://{aws_host}:{aws_port}")
+    monkeypatch.setenv("HTTPS_PROXY", f"http://{aws_host}:{aws_port}")
+
+
+@pytest.fixture
+def aws_region(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    yield AWS_REGION
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+
+@pytest.fixture
+def aws_credentials(aws_region, monkeypatch):
+    """Mocked AWS Credentials for moto."""
+    boto3.DEFAULT_SESSION = None
+    # monkeypatch.setenv("AWS_DEFAULT_PROFILE", "testing")
+    # monkeypatch.setenv("AWS_PROFILE", "testing")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    yield
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_SECURITY_TOKEN", raising=False)
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+
+
+@pytest.fixture(scope="session")
+def job_queue_name():
+    return "moto_test_job_queue"
+
+
+@pytest.fixture(scope="session")
+def job_definition_name():
+    return "moto_test_job_definition"
+
+
+@pytest.fixture(scope="session")
+def compute_env_name():
+    return "moto_test_compute_env"
+
+
+#
+# AWS Clients
+#
+
+
+@pytest.fixture
+def aws_batch_client(aws_region):
+    with mock_batch():
+        yield boto3.client("batch", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_ec2_client(aws_region):
+    with mock_ec2():
+        yield boto3.client("ec2", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_ecs_client(aws_region):
+    with mock_ecs():
+        yield boto3.client("ecs", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_iam_client(aws_region):
+    with mock_iam():
+        yield boto3.client("iam", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_logs_client(aws_region):
+    with mock_logs():
+        yield boto3.client("logs", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_s3_client(aws_region):
+    with mock_s3():
+        yield boto3.client("s3", region_name=aws_region)
+
+
+@pytest.fixture
+def aws_s3_resource(aws_region):
+    with mock_s3():
+        yield boto3.resource("s3", region_name=aws_region)
+
+
+##################################################################
+#
+# Generic S3 bucket and key fixtures
+#
+
+
+def assert_bucket_200(bucket, s3_client):
+    head = s3_client.head_bucket(Bucket=bucket)
+    assert_status_code(head, 200)
+
+
+def assert_bucket_404(bucket, s3_client):
+    try:
+        head = s3_client.head_bucket(Bucket=bucket)
+        assert_status_code(head, 404)
+    except botocore.exceptions.ClientError as err:
+        resp = err.response
+        assert_status_code(resp, 404)
+
+
+def assert_object_200(bucket, key, s3_client):
+    head = s3_client.head_object(Bucket=bucket, Key=key)
+    assert_status_code(head, 200)
+
+
+def assert_object_404(bucket, key, s3_client):
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+        assert_status_code(head, 404)
+    except botocore.exceptions.ClientError as err:
+        resp = err.response
+        assert_status_code(resp, 404)
+
+
+def create_s3_bucket(bucket_name, s3_client, aws_region):
+    resp = s3_client.create_bucket(
+        Bucket=bucket_name,
+        ACL="public-read-write",
+        CreateBucketConfiguration={"LocationConstraint": aws_region},
+    )
+    assert response_success(resp)
+    exists_waiter = s3_client.get_waiter("bucket_exists")
+    exists_waiter.wait(Bucket=bucket_name)
+    head = s3_client.head_bucket(Bucket=bucket_name)
+    assert response_success(head)
+
+
+def create_s3_bucket_resource(bucket_name, s3_resource, aws_region) -> "s3.Bucket":
+    bucket = s3_resource.create_bucket(
+        Bucket=bucket_name,
+        ACL="public-read-write",
+        CreateBucketConfiguration={"LocationConstraint": aws_region},
+    )
+    bucket.wait_until_exists()
+    s3_client = s3_resource.meta.client
+    head = s3_client.head_bucket(Bucket=bucket_name)
+    assert response_success(head)
+    return bucket
+
+
+def create_s3_object(
+    bucket_name, key, object_body, s3_resource, s3_client
+) -> "s3.ObjectSummary":
+    bucket = s3_resource.Bucket(bucket_name)
+    s3_obj = bucket.put_object(Key=key, Body=object_body)
+    exists_waiter = s3_client.get_waiter("object_exists")
+    exists_waiter.wait(Bucket=bucket_name, Key=key)
+    head = s3_client.head_object(Bucket=bucket_name, Key=key)
+    assert response_success(head)
+    return s3_obj
+
+
+def delete_s3_bucket(bucket_name, s3_client):
+    # Recursively deletes a bucket and all of its contents.
+
+    try:
+        # - ensure the s3-client is loaded with moto mocks
+        # - never allow this to apply to live s3 resources
+        # - the event-name mocks are dynamically generated after calling the method
+        assert has_moto_mocks(s3_client, "before-send.s3.HeadBucket")
+
+        paginator = s3_client.get_paginator("list_object_versions")
+
+        for n in paginator.paginate(Bucket=bucket_name, Prefix=""):
+            for obj in chain(
+                n.get("Versions", []),
+                n.get("DeleteMarkers", []),
+                n.get("Contents", []),
+                n.get("CommonPrefixes", []),
+            ):
+                kwargs = dict(Bucket=bucket_name, Key=obj["Key"])
+                if "VersionId" in obj:
+                    kwargs["VersionId"] = obj["VersionId"]
+                resp = s3_client.delete_object(**kwargs)
+                assert response_success(resp)
+
+        resp = s3_client.delete_bucket(Bucket=bucket_name)
+        assert response_success(resp)
+        # Ensure the bucket is gone
+        waiter = s3_client.get_waiter("bucket_not_exists")
+        waiter.wait(Bucket=bucket_name)
+        try:
+            head = s3_client.head_bucket(Bucket=bucket_name)
+            assert_status_code(head, 404)
+        except ClientError as err:
+            resp = err.response
+            assert_status_code(resp, 404)
+
+    except ClientError as err:
+        print(f"COULD NOT CLEANUP S3 BUCKET: {bucket_name}")
+        print(err)
+
+
+def delete_s3_bucket_resource(bucket_name, s3_resource):
+    delete_s3_bucket(bucket_name, s3_resource.meta.client)
+
+
+def delete_s3_prefix(s3_client, bucket_name, prefix):
+    try:
+        # - ensure the s3-client is loaded with moto mocks
+        # - never allow this to apply to live s3 resources
+        # - the event-name mocks are dynamically generated after calling the method
+        assert has_moto_mocks(s3_client, "before-send.s3.HeadBucket")
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for objects in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+            if objects["KeyCount"]:
+                keys = [{"Key": obj["Key"]} for obj in objects["Contents"]]
+                s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": keys})
+    except ClientError as err:
+        print(f"COULD NOT CLEANUP S3 PREFIX: s3://{bucket_name}/{prefix}")
+        print(err)
+
+
+@pytest.fixture
+def s3_protocol() -> str:
+    """An s3:// protocol prefix"""
+    return "s3://"
+
+
+@pytest.fixture
+def s3_bucket_name() -> str:
+    """
+    A valid S3 bucket name with a UUID suffix.
+
+    This bucket may not exist yet; for a bucket that exists, use
+    the `s3_bucket` fixture instead.  It creates a moto-bucket
+    for this bucket name.
+
+    :return: str for the bucket component of 's3://{bucket}/{key}'
+    """
+    return "moto-bucket-" + str(uuid.uuid4())
+
+
+@pytest.fixture
+def s3_bucket(s3_bucket_name, aws_s3_client, aws_region) -> str:
+    """
+    The s3_bucket fixture provides a moto-bucket for the s3_bucket_name
+    fixture, where the moto-bucket is cleaned up on exit.
+    :return: the s3_bucket_name
+    """
+    with mock_s3():
+        create_s3_bucket(s3_bucket_name, aws_s3_client, aws_region)
+        yield s3_bucket_name
+        delete_s3_bucket(s3_bucket_name, aws_s3_client)
+
+
+@pytest.fixture
+def s3_bucket_resource(s3_bucket_name, aws_s3_resource, aws_region) -> "s3.Bucket":
+    """
+    The s3_bucket fixture provides a moto-bucket for the s3_bucket_name
+    fixture, where the moto-bucket is cleaned up on exit.
+    :return: the s3.Bucket resource
+    """
+    with mock_s3():
+        bucket = create_s3_bucket_resource(s3_bucket_name, aws_s3_resource, aws_region)
+        yield bucket
+        delete_s3_bucket_resource(s3_bucket_name, aws_s3_resource)
+
+
+@pytest.fixture
+def s3_buckets(s3_bucket_name, aws_s3_client, aws_region) -> List[str]:
+    """
+    The s3_buckets fixture creates moto-buckets for the s3_bucket_name
+    fixture, with a numeric suffix for each bucket, where the
+    moto-buckets are cleaned up on exit.
+    :return: a list of bucket names
+    """
+    with mock_s3():
+        bucket_names = []
+        for i in range(10):
+            bucket_name = f"{s3_bucket_name}-{i:02d}"
+            create_s3_bucket(bucket_name, aws_s3_client, aws_region)
+            bucket_names.append(bucket_name)
+
+        yield bucket_names
+
+        for bucket_name in bucket_names:
+            delete_s3_bucket(bucket_name, aws_s3_client)
+
+
+@pytest.fixture(scope="session")
+def s3_key_path() -> str:
+    """A valid S3 key name that is not a file name, it's like a directory
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_path}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return "s3_key_path"
+
+
+@pytest.fixture(scope="session")
+def s3_key_file() -> str:
+    """A valid S3 key name that is also a file name
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_file}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return "s3_file_test.txt"
+
+
+@pytest.fixture(scope="session")
+def s3_key(s3_key_path, s3_key_file) -> str:
+    """A valid S3 key composed of a key_path and a key_file
+    The key component of 's3://{bucket}/{key}' that is composed of '{key_path}/{key_file}';
+    the key does not begin or end with any delimiters (e.g. '/')
+    :return: str for the key component of 's3://{bucket}/{key}'
+    """
+    return f"{s3_key_path}/{s3_key_file}"
+
+
+@pytest.fixture(scope="session")
+def s3_object_text() -> str:
+    """s3 object data: 's3 test object text\n'"""
+    return "s3 test object text\n"
+
+
+@pytest.fixture
+def s3_uri_str(s3_protocol, s3_bucket_name, s3_key) -> str:
+    """A valid S3 URI comprised of 's3://{bucket}/{key}'
+
+    This s3_uri_str may not exist yet; for an object that exists, use
+    the `s3_uri_object` fixture instead.
+
+    :return: str
+    """
+    return f"{s3_protocol}{s3_bucket_name}/{s3_key}"
+
+
+@pytest.fixture
+def s3_uri_object(
+    aws_s3_client, aws_s3_resource, aws_region, s3_bucket_name, s3_key, s3_object_text
+) -> S3Object:
+    """
+    The s3_uri_object fixture creates a moto-bucket and moto-object for
+    the s3_uri_str fixture, where the moto-bucket is cleaned up on exit.
+    :return: an S3Object(bucket=s3_bucket_name, key=s3_key)
+    """
+    with mock_s3():
+        create_s3_bucket(s3_bucket_name, aws_s3_client, aws_region)
+        create_s3_object(
+            s3_bucket_name, s3_key, s3_object_text, aws_s3_resource, aws_s3_client
+        )
+        yield S3Object(bucket=s3_bucket_name, key=s3_key)
+        delete_s3_bucket(s3_bucket_name, aws_s3_client)
+
+
+@pytest.fixture
+def s3_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def s3_dynamic_uri(s3_bucket, s3_bucket_name, s3_key_path, s3_uuid) -> S3Object:
+    uuid_prefix = f"{s3_key_path}/{s3_uuid}"
+    yield S3Object(bucket=s3_bucket_name, key=uuid_prefix)
+
+
+@pytest.fixture
+def s3_temp_dir(s3_key_path, s3_uuid) -> str:
+    return f"{s3_key_path}/{s3_uuid}"
+
+
+@pytest.fixture
+def s3_temp_file(
+    aws_s3_client, aws_s3_resource, s3_bucket, s3_temp_dir, s3_uuid
+) -> S3Object:
+    file_path = f"{s3_temp_dir}/{s3_uuid}.txt"
+    aws_s3_resource.Object(s3_bucket, file_path).put(Body="foo".encode())
+
+    yield S3Object(bucket=s3_bucket, key=file_path)
+
+    delete_s3_prefix(aws_s3_client, s3_bucket, s3_temp_dir)
+
+
+@pytest.fixture
+def s3_temp_objects(
+    aws_s3_client, aws_s3_resource, s3_bucket, s3_temp_dir, s3_uuid
+) -> List[S3Object]:
+    """
+    This creates 10 files, 5 with .txt and 5 with .tif file extensions,
+    below the s3://s3_bucket/s3_temp_dir path
+    """
+    # Since a mock_s3 context is created by the s3_bucket
+    # and aws_s3_client fixtures, it is not required here.
+
+    file_key = f"{s3_temp_dir}/{s3_uuid}.txt"
+    s3_file = create_s3_object(
+        s3_bucket, file_key, s3_uuid, aws_s3_resource, aws_s3_client
+    )
+    s3_objects = [s3_file]
+
+    files_prefix = f"{s3_temp_dir}/{s3_uuid}"
+    for i in range(10):
+        file_stem = f"{files_prefix}_{i:04d}"
+        if i % 2 > 0:
+            key = f"{file_stem}.txt"
+        else:
+            key = f"{file_stem}.tif"
+        body = file_stem.encode()
+        s3_obj = create_s3_object(s3_bucket, key, body, aws_s3_resource, aws_s3_client)
+        s3_objects.append(s3_obj)
+
+    # create a sub-key path for derivative files
+    derivative_path = str(uuid.uuid4())
+    derivative_prefix = f"{s3_temp_dir}/{derivative_path}/{s3_uuid}"
+    for i in range(10):
+        file_stem = f"{derivative_prefix}_{i:04d}"
+        if i % 2 > 0:
+            key = f"{file_stem}.txt"
+        else:
+            key = f"{file_stem}.tif"
+        body = file_stem.encode()
+        s3_obj = create_s3_object(s3_bucket, key, body, aws_s3_resource, aws_s3_client)
+        s3_objects.append(s3_obj)
+
+    s3_objects = [
+        S3Object(bucket=s3_obj.bucket_name, key=s3_obj.key) for s3_obj in s3_objects
+    ]
+
+    yield s3_objects
+
+    delete_s3_prefix(aws_s3_client, s3_bucket, s3_temp_dir)
+
+
+@pytest.fixture
+def s3_temp_1000s_objects(
+    aws_s3_client, aws_s3_resource, s3_bucket, s3_temp_dir, s3_uuid
+) -> List[S3Object]:
+    """
+    This creates 1010 files, half with .txt and others with .tif file extensions,
+    below the s3://s3_bucket/s3_temp_dir path; the default page limit for s3
+    object listings is usually 1000, so this should exceed 1 page.
+    """
+    # Since a mock_s3 context is created by the s3_bucket
+    # and aws_s3_client fixtures, it is not required here.
+    file_key = f"{s3_temp_dir}/{s3_uuid}.txt"
+    s3_file = create_s3_object(
+        s3_bucket, file_key, s3_uuid, aws_s3_resource, aws_s3_client
+    )
+    s3_objects = [s3_file]
+
+    for i in range(1010):
+        if i % 2 > 0:
+            key = f"{s3_temp_dir}/{s3_uuid}_{i:04d}.txt"
+        else:
+            key = f"{s3_temp_dir}/{s3_uuid}_{i:04d}.tif"
+        body = f"{s3_uuid}-{i:04d}".encode()
+        s3_obj = create_s3_object(s3_bucket, key, body, aws_s3_resource, aws_s3_client)
+        s3_objects.append(s3_obj)
+
+    s3_objects = [
+        S3Object(bucket=s3_obj.bucket_name, key=s3_obj.key) for s3_obj in s3_objects
+    ]
+
+    yield s3_objects
+
+    delete_s3_prefix(aws_s3_client, s3_bucket, s3_temp_dir)
+
+
+#
+# Batch Infrastructure
+#
+
+
+class AwsBatchClients(NamedTuple):
+    batch: "botocore.client.Batch"
+    ec2: "botocore.client.EC2"
+    ecs: "botocore.client.ECS"
+    iam: "botocore.client.IAM"
+    logs: "botocore.client.CloudWatchLogs"
+    region: str
+
+
+@pytest.fixture
+def aws_batch_clients(
+    aws_batch_client,
+    aws_ec2_client,
+    aws_ecs_client,
+    aws_iam_client,
+    aws_logs_client,
+    aws_region,
+):
+    return AwsBatchClients(
+        batch=aws_batch_client,
+        ec2=aws_ec2_client,
+        ecs=aws_ecs_client,
+        iam=aws_iam_client,
+        logs=aws_logs_client,
+        region=aws_region,
+    )
+
+
+class AwsBatchInfrastructure:
+    aws_region: str
+    aws_clients: AwsBatchClients
+    vpc_id: Optional[str] = None
+    subnet_id: Optional[str] = None
+    security_group_id: Optional[str] = None
+    iam_arn: Optional[str] = None
+    compute_env_name: Optional[str] = None
+    compute_env_arn: Optional[str] = None
+    job_queue_name: Optional[str] = None
+    job_queue_arn: Optional[str] = None
+    job_definition_name: Optional[str] = None
+    job_definition_arn: Optional[str] = None
+
+
+def batch_infrastructure(
+    aws_clients: AwsBatchClients,
+    compute_env_name: str,
+    job_queue_name: str,
+    job_definition_name: str,
+) -> AwsBatchInfrastructure:
+    """
+    Create AWS Batch infrastructure, including:
+    - VPC with subnet
+    - Security group and IAM role
+    - Batch compute environment and job queue
+    - Batch job job_definition
+
+    This function is not a fixture so that tests can pass the AWS clients to it and then
+    continue to use the infrastructure created by it while the client fixtures are in-tact for
+    the duration of a test.
+    """
+
+    infrastructure = AwsBatchInfrastructure()
+    infrastructure.aws_region = aws_clients.region
+    infrastructure.aws_clients = aws_clients
+
+    resp = aws_clients.ec2.create_vpc(CidrBlock="172.30.0.0/24")
+    vpc_id = resp["Vpc"]["VpcId"]
+
+    resp = aws_clients.ec2.create_subnet(
+        AvailabilityZone=f"{aws_clients.region}a",
+        CidrBlock="172.30.0.0/25",
+        VpcId=vpc_id,
+    )
+    subnet_id = resp["Subnet"]["SubnetId"]
+
+    resp = aws_clients.ec2.create_security_group(
+        Description="moto_test_sg_desc", GroupName="moto_test_sg", VpcId=vpc_id
+    )
+    sg_id = resp["GroupId"]
+
+    resp = aws_clients.iam.create_role(
+        RoleName="MotoTestRole", AssumeRolePolicyDocument="moto_test_policy"
+    )
+    iam_arn = resp["Role"]["Arn"]
+
+    resp = aws_clients.batch.create_compute_environment(
+        computeEnvironmentName=compute_env_name,
+        type="UNMANAGED",
+        state="ENABLED",
+        serviceRole=iam_arn,
+    )
+    compute_env_arn = resp["computeEnvironmentArn"]
+
+    resp = aws_clients.batch.create_job_queue(
+        jobQueueName=job_queue_name,
+        state="ENABLED",
+        priority=123,
+        computeEnvironmentOrder=[{"order": 123, "computeEnvironment": compute_env_arn}],
+    )
+    assert resp["jobQueueName"] == job_queue_name
+    assert resp["jobQueueArn"]
+    job_queue_arn = resp["jobQueueArn"]
+
+    resp = aws_clients.batch.register_job_definition(
+        jobDefinitionName=job_definition_name,
+        type="container",
+        containerProperties={
+            "image": "busybox",
+            "vcpus": 2,
+            "memory": 8,
+            "command": ["sleep", "10"],  # NOTE: job runs for 10 sec without overrides
+        },
+    )
+    assert resp["jobDefinitionName"] == job_definition_name
+    assert resp["jobDefinitionArn"]
+    job_definition_arn = resp["jobDefinitionArn"]
+    assert resp["revision"]
+    assert resp["jobDefinitionArn"].endswith(
+        "{0}:{1}".format(resp["jobDefinitionName"], resp["revision"])
+    )
+
+    infrastructure.vpc_id = vpc_id
+    infrastructure.subnet_id = subnet_id
+    infrastructure.security_group_id = sg_id
+    infrastructure.iam_arn = iam_arn
+    infrastructure.compute_env_name = compute_env_name
+    infrastructure.compute_env_arn = compute_env_arn
+    infrastructure.job_queue_name = job_queue_name
+    infrastructure.job_queue_arn = job_queue_arn
+    infrastructure.job_definition_name = job_definition_name
+    infrastructure.job_definition_arn = job_definition_arn
+    return infrastructure

--- a/pytest_aiomoto/aws_lambda.py
+++ b/pytest_aiomoto/aws_lambda.py
@@ -1,0 +1,56 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AWS Lambda Utilities for Testing
+
+"""
+import inspect
+import io
+import zipfile
+
+
+def lambda_handler(event, context):
+    """
+    A lambda handler for test purposes.
+    This function must be self-contained, including imports required.
+    """
+    import sys
+
+    print("event: %s" % event)
+    action = event.get("action")
+    if action == "too-large":
+        x = ["xxx" for x in range(10 ** 6)]
+        assert sys.getsizeof(x) > 6291556
+        return {"statusCode": 200, "body": x}
+    if action == "runtime-error":
+        raise RuntimeError(action)
+    return {"statusCode": 200, "body": event}
+
+
+def aws_lambda_src() -> str:
+    return inspect.getsource(lambda_handler)
+
+
+def aws_lambda_zip() -> bytes:
+    return zip_lambda(aws_lambda_src())
+
+
+def zip_lambda(func_str) -> bytes:
+    zip_output = io.BytesIO()
+    zip_file = zipfile.ZipFile(zip_output, "w", zipfile.ZIP_DEFLATED)
+    zip_file.writestr("lambda_function.py", func_str)
+    zip_file.close()
+    zip_output.seek(0)
+    return zip_output.read()

--- a/pytest_aiomoto/moto_services.py
+++ b/pytest_aiomoto/moto_services.py
@@ -1,0 +1,145 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+import os
+import threading
+import time
+
+import moto.backends
+import moto.server
+import urllib3
+import werkzeug.serving
+
+from pytest_aiomoto.utils import AWS_HOST
+from pytest_aiomoto.utils import get_free_tcp_port
+
+_PYCHARM_HOSTED = os.environ.get("PYCHARM_HOSTED") == "1"
+CONNECT_TIMEOUT = 90 if _PYCHARM_HOSTED else 10
+
+
+class MotoService:
+    """Will Create MotoService.
+    Service is ref-counted so there will only be one per process. Real Service will
+    be returned by `__enter__`."""
+
+    _services = dict()  # {name: instance}
+
+    def __init__(self, service_name: str, port: int = None):
+        self._service_name = service_name
+
+        if port:
+            self._socket = None
+            self._port = port
+        else:
+            self._socket, self._port = get_free_tcp_port()
+
+        self._thread = None
+        self._logger = logging.getLogger("MotoService")
+        self._refcount = 0
+        self._ip_address = AWS_HOST
+        self._server = None
+
+    @property
+    def endpoint_url(self):
+        return "http://{}:{}".format(self._ip_address, self._port)
+
+    def reset(self):
+        # each service can have multiple regional backends
+        service_backends = moto.server.backends.get_backend(self._service_name)
+        for region_name, backend in service_backends.items():
+            backend.reset()
+
+    def __call__(self, func):
+        def wrapper(*args, **kwargs):
+            self._start()
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                self._stop()
+            return result
+
+        functools.update_wrapper(wrapper, func)
+        wrapper.__wrapped__ = func
+        return wrapper
+
+    def __enter__(self):
+        svc = self._services.get(self._service_name)
+        if svc is None:
+            self._services[self._service_name] = self
+            self._refcount = 1
+            self._start()
+            return self
+        else:
+            svc._refcount += 1
+            return svc
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._refcount -= 1
+
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+
+        if self._refcount == 0:
+            del self._services[self._service_name]
+            self._stop()
+
+    def _server_entry(self):
+        self._main_app = moto.server.DomainDispatcherApplication(
+            moto.server.create_backend_app, service=self._service_name
+        )
+        self._main_app.debug = True
+
+        if self._socket:
+            self._socket.close()  # release right before we use it
+            self._socket = None
+
+        self._server = werkzeug.serving.make_server(
+            self._ip_address, self._port, self._main_app, True
+        )
+        self._server.serve_forever()
+
+    def _start(self):
+        self._thread = threading.Thread(target=self._server_entry, daemon=True)
+        self._thread.start()
+
+        http = urllib3.PoolManager()
+
+        start = time.time()
+
+        while time.time() - start < 10:
+            if not self._thread.is_alive():
+                break
+
+            try:
+                resp = http.request(
+                    "GET", self.endpoint_url + "/static", timeout=CONNECT_TIMEOUT
+                )
+                break
+            except (
+                urllib3.exceptions.NewConnectionError,
+                urllib3.exceptions.MaxRetryError,
+            ):
+                time.sleep(0.2)
+        else:
+            self._stop()  # pytest.fail doesn't call stop_process
+            raise Exception("Cannot start MotoService: {}".format(self._service_name))
+
+    def _stop(self):
+        if self._server:
+            self._server.shutdown()
+
+        self._thread.join()

--- a/pytest_aiomoto/plugin.py
+++ b/pytest_aiomoto/plugin.py
@@ -1,0 +1,18 @@
+
+pytest_plugins = [
+    "pytest_aiomoto.aws_fixtures",
+    "pytest_aiomoto.aiomoto_fixtures",
+    "pytest_aiomoto.aiomoto_lambda",
+    "pytest_aiomoto.aiomoto_s3",
+]
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "aws_live: tests that require credentials for live AWS network requests"
+    )
+    config.addinivalue_line(
+        "markers",
+        "aws_s3: tests that require credentials for live AWS S3 network requests"
+    )

--- a/pytest_aiomoto/pytest_aiomoto.py
+++ b/pytest_aiomoto/pytest_aiomoto.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+# TODO: remove or adapt this module
+
+def pytest_addoption(parser):
+    group = parser.getgroup('aiomoto')
+    group.addoption(
+        '--foo',
+        action='store',
+        dest='dest_foo',
+        default='2021',
+        help='Set the value for the fixture "bar".'
+    )
+
+    parser.addini('HELLO', 'Dummy pytest.ini setting')
+
+
+@pytest.fixture
+def bar(request):
+    return request.config.option.dest_foo

--- a/pytest_aiomoto/s3_object.py
+++ b/pytest_aiomoto/s3_object.py
@@ -1,0 +1,20 @@
+from typing import NamedTuple
+
+
+class S3Object(NamedTuple):
+    """
+    Just the bucket_name and key for an :code:`s3.ObjectSummary`.
+    This simple named tuple should work around problems with :code:`Pickle`
+    for an :code:`s3.ObjectSummary`
+    """
+
+    bucket: str
+    key: str
+
+    @property
+    def bucket_name(self) -> str:
+        return self.bucket
+
+    @property
+    def s3_uri(self) -> str:
+        return f"s3://{self.bucket}/{self.key}"

--- a/pytest_aiomoto/utils.py
+++ b/pytest_aiomoto/utils.py
@@ -1,0 +1,72 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import socket
+from typing import Dict
+
+from moto.core.models import BotocoreStubber
+
+AWS_HOST = "127.0.0.1"
+AWS_PORT = "5000"
+
+AWS_REGION = "us-west-2"
+AWS_ACCESS_KEY_ID = "test_AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "test_AWS_SECRET_ACCESS_KEY"
+
+
+def assert_status_code(response, status_code: int):
+    assert (
+        int(response.get("ResponseMetadata", {}).get("HTTPStatusCode")) == status_code
+    )
+
+
+def get_free_tcp_port(release_socket: bool = False):
+    sckt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sckt.bind(("", 0))
+    addr, port = sckt.getsockname()
+    if release_socket:
+        sckt.close()
+        return port
+
+    return sckt, port
+
+
+def has_moto_mocks(client, event_name):
+    # moto registers mock callbacks with the `before-send` event-name, using
+    # specific callbacks for the methods that are generated dynamically. By
+    # checking that the first callback is a BotocoreStubber, this verifies
+    # that moto mocks are intercepting client requests.
+    callbacks = client.meta.events._emitter._lookup_cache[event_name]
+    if len(callbacks) > 0:
+        stub = callbacks[0]
+        assert isinstance(stub, BotocoreStubber)
+        return stub.enabled
+    return False
+
+
+def response_success(response: Dict) -> bool:
+    """
+    Parse a response from a request issued by any botocore.client.BaseClient
+    to determine whether the request was successful or not.
+    :param response:
+    :return: boolean
+    :raises: KeyError if the response is not an AWS response
+    """
+    # If the response dict is not constructed as expected for an AWS response,
+    # this should raise a KeyError to indicate something is very wrong.
+    status_code = int(response["ResponseMetadata"]["HTTPStatusCode"])
+    if status_code:
+        # consider 300+ responses to be unsuccessful
+        return 200 <= status_code < 300
+    else:
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pytest_plugins = [
+    "pytester",
+]

--- a/tests/test_aio_aws_batch.py
+++ b/tests/test_aio_aws_batch.py
@@ -1,0 +1,134 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Asyncio AWS Batch
+
+This test suite uses a large suite of moto mocks for the AWS batch
+infrastructure. These infrastructure mocks are derived from the moto test
+suite for testing the batch client. The test infrastructure should be used
+according to the moto license (Apache-2.0).
+
+.. seealso::
+
+    - https://github.com/spulec/moto/pull/1197/files
+    - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+"""
+
+import pytest
+
+from pytest_aiomoto.aiomoto_fixtures import AioAwsBatchClients
+from pytest_aiomoto.aiomoto_fixtures import AioAwsBatchInfrastructure
+from pytest_aiomoto.aiomoto_fixtures import aio_batch_infrastructure
+from pytest_aiomoto.aws_batch_models import AWSBatchJobStates
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.fixture
+async def aio_aws_batch_infrastructure(
+    aio_aws_batch_clients: AioAwsBatchClients,
+    compute_env_name: str,
+    job_queue_name: str,
+    job_definition_name: str,
+) -> AioAwsBatchInfrastructure:
+    aws_region = aio_aws_batch_clients.region
+    aws_resources = await aio_batch_infrastructure(
+        aio_aws_batch_clients,
+        aws_region,
+        compute_env_name,
+        job_queue_name,
+        job_definition_name,
+    )
+    return aws_resources
+
+
+@pytest.mark.asyncio
+async def test_aws_batch_infrastructure(
+    aio_aws_batch_infrastructure: AioAwsBatchInfrastructure,
+):
+    infrastructure = aio_aws_batch_infrastructure
+    assert infrastructure
+    assert infrastructure.vpc_id
+    assert infrastructure.subnet_id
+    assert infrastructure.security_group_id
+    assert infrastructure.iam_arn
+    assert infrastructure.compute_env_name
+    assert infrastructure.compute_env_arn
+    assert infrastructure.job_queue_name
+    assert infrastructure.job_queue_arn
+    assert infrastructure.job_definition_name
+    assert infrastructure.job_definition_arn
+
+
+@pytest.mark.asyncio
+async def test_aio_batch_job_definitions(
+    aio_aws_batch_infrastructure: AioAwsBatchInfrastructure,
+):
+    aws_resources = aio_aws_batch_infrastructure
+    aws_region = aws_resources.aws_region
+    job_definition_name = aws_resources.job_definition_name
+
+    assert aws_resources
+    assert aws_resources.job_definition_arn
+    assert f"arn:aws:batch:{aws_region}" in aws_resources.job_definition_arn
+    assert job_definition_name in aws_resources.job_definition_arn
+
+    clients = aio_aws_batch_infrastructure.aio_aws_clients
+    response = await clients.batch.describe_job_definitions()
+    assert response_success(response)
+    job_definitions = response["jobDefinitions"]
+    assert len(job_definitions) == 1
+    job_definition = job_definitions[0]
+    assert job_definition["jobDefinitionArn"] == aws_resources.job_definition_arn
+    assert job_definition["jobDefinitionName"] == aws_resources.job_definition_name
+
+
+@pytest.mark.asyncio
+async def test_aio_batch_job_queues(
+    aio_aws_batch_infrastructure: AioAwsBatchInfrastructure,
+):
+    aws_resources = aio_aws_batch_infrastructure
+    aws_region = aws_resources.aws_region
+    job_queue_name = aws_resources.job_queue_name
+
+    assert aws_resources
+    assert aws_resources.job_queue_arn
+    assert f"arn:aws:batch:{aws_region}" in aws_resources.job_queue_arn
+    assert job_queue_name in aws_resources.job_queue_arn
+
+    clients = aio_aws_batch_infrastructure.aio_aws_clients
+    response = await clients.batch.describe_job_queues()
+    assert response_success(response)
+    job_queues = response["jobQueues"]
+    assert len(job_queues) == 1
+    job_queue = job_queues[0]
+    assert job_queue["jobQueueArn"] == aws_resources.job_queue_arn
+    assert job_queue["jobQueueName"] == aws_resources.job_queue_name
+
+
+@pytest.mark.asyncio
+async def test_aio_batch_list_jobs(
+    aio_aws_batch_infrastructure: AioAwsBatchInfrastructure,
+):
+    clients = aio_aws_batch_infrastructure.aio_aws_clients
+    job_queue_name = aio_aws_batch_infrastructure.job_queue_name
+    
+    job_states = [state.name for state in AWSBatchJobStates]
+
+    for job_status in job_states:
+        response = await clients.batch.list_jobs(
+            jobQueue=job_queue_name, jobStatus=job_status
+        )
+        assert response_success(response)
+        assert response["jobSummaryList"] == []

--- a/tests/test_aio_aws_lambda.py
+++ b/tests/test_aio_aws_lambda.py
@@ -1,0 +1,145 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Asyncio AWS Lambda
+
+"""
+import json
+from typing import Dict
+
+import pytest
+
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.mark.asyncio
+async def test_async_lambda_invoke_success(aws_lambda_func, aio_aws_lambda_client):
+
+    event = {"i": 0}
+    payload = json.dumps(event).encode()
+    params = {
+        "FunctionName": aws_lambda_func,
+        "InvocationType": "RequestResponse",
+        "LogType": "None",
+        "Payload": payload
+    }
+
+    response = await aio_aws_lambda_client.invoke(**params)
+
+    assert response.get("StatusCode") == 200
+    assert response_success(response)
+
+    metadata = response.get("ResponseMetadata")
+    headers = metadata.get("HTTPHeaders")
+
+    content_type = headers.get("content-type")
+    assert content_type == "application/json"
+
+    content_length = int(headers.get("content-length"))
+    assert content_length > 0
+
+    response_payload = response.get("Payload")
+    if response_payload:
+        async with response_payload as stream:
+            data = await stream.read()
+
+    # since this function should work, test the response data
+    data = data.decode()
+    body = json.loads(data)
+    assert body == {"statusCode": 200, "body": event}
+
+
+@pytest.mark.skip("https://github.com/spulec/moto/issues/3988")
+@pytest.mark.asyncio
+async def test_async_lambda_invoke_too_large(aws_lambda_func, aio_aws_lambda_client):
+    # TODO: see also stub issue at https://github.com/aio-libs/aiobotocore/issues/781
+
+    event = {"action": "too-large"}
+    payload = json.dumps(event).encode()
+    params = {
+        "FunctionName": aws_lambda_func,
+        "InvocationType": "RequestResponse",
+        "LogType": "None",
+        "Payload": payload
+    }
+
+    response = await aio_aws_lambda_client.invoke(**params)
+
+    # Note that Lambda still has a 200 response code for errors
+    assert response.get("StatusCode") == 200
+    assert response_success(response)
+
+    metadata = response.get("ResponseMetadata")
+    headers = metadata.get("HTTPHeaders")
+
+    content_length = int(headers.get("content-length"))
+    assert content_length > 0
+
+    response_payload = response.get("Payload")
+    if response_payload:
+        async with response_payload as stream:
+            data = await stream.read()
+
+    # lambda function error
+    lambda_error = {
+        "errorMessage": "Response payload size exceeded maximum allowed payload size (6291556 bytes).",
+        "errorType": "Function.ResponseSizeTooLarge",
+    }
+    # assert response.get("FunctionError")
+    error = data.decode()
+    error = json.loads(error)
+    assert isinstance(error, Dict)
+    assert error.get("errorType") == lambda_error.get("errorType")
+    assert error.get("errorMessage") == lambda_error.get("errorMessage")
+    assert error.get("stackTrace")
+
+
+@pytest.mark.asyncio
+async def test_async_lambda_invoke_error(aws_lambda_func, aio_aws_lambda_client):
+
+    event = {"action": "runtime-error"}
+    payload = json.dumps(event).encode()
+    params = {
+        "FunctionName": aws_lambda_func,
+        "InvocationType": "RequestResponse",
+        "LogType": "None",
+        "Payload": payload
+    }
+
+    response = await aio_aws_lambda_client.invoke(**params)
+
+    # Note that Lambda still has a 200 response code for errors
+    assert response.get("StatusCode") == 200
+    assert response_success(response)
+
+    metadata = response.get("ResponseMetadata")
+    headers = metadata.get("HTTPHeaders")
+
+    content_length = int(headers.get("content-length"))
+    assert content_length > 0
+
+    response_payload = response.get("Payload")
+    if response_payload:
+        async with response_payload as stream:
+            data = await stream.read()
+
+    # lambda function error
+    assert response.get("FunctionError")
+    error = data.decode()
+    error = json.loads(error)
+    assert isinstance(error, Dict)
+    assert error.get("errorType") == "RuntimeError"
+    assert error.get("errorMessage") == "runtime-error"
+    assert error.get("stackTrace")

--- a/tests/test_aio_aws_s3.py
+++ b/tests/test_aio_aws_s3.py
@@ -1,0 +1,94 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import aiobotocore
+import aiobotocore.client
+import aiobotocore.config
+import botocore.exceptions
+import pytest
+from aiobotocore.session import get_session
+
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.mark.asyncio
+async def test_aio_s3_list_bucket(aio_aws_s3_client, aio_s3_bucket):
+    resp = await aio_aws_s3_client.list_buckets()
+    assert response_success(resp)
+    bucket_names = [b["Name"] for b in resp["Buckets"]]
+    assert bucket_names == [aio_s3_bucket]
+
+
+@pytest.mark.asyncio
+async def test_aio_s3_list_buckets(aio_aws_s3_client, aio_s3_buckets):
+    resp = await aio_aws_s3_client.list_buckets()
+    assert response_success(resp)
+    bucket_names = [b["Name"] for b in resp["Buckets"]]
+    assert bucket_names == aio_s3_buckets
+
+
+@pytest.mark.asyncio
+async def test_aio_s3_object_head(
+    aio_s3_bucket_name, aio_s3_key, aio_s3_bucket, aio_s3_object_text, aio_aws_s3_client
+):
+    resp = await aio_aws_s3_client.put_object(
+        Bucket=aio_s3_bucket_name,
+        Key=aio_s3_key,
+        Body=aio_s3_object_text,
+        ACL="public-read-write",
+    )
+    assert response_success(resp)
+    resp = await aio_aws_s3_client.head_object(Bucket=aio_s3_bucket_name, Key=aio_s3_key)
+    assert response_success(resp)
+
+
+@pytest.mark.asyncio
+async def test_aio_s3_bucket_head_not_authorized():
+
+    session = get_session()
+    aio_config = aiobotocore.config.AioConfig(max_pool_connections=1)
+    session.set_default_client_config(aio_config)
+    session.set_credentials("fake_AWS_ACCESS_KEY_ID", "fake_AWS_SECRET_ACCESS_KEY")
+
+    async with session.create_client("s3") as client:
+        with pytest.raises(botocore.exceptions.ClientError) as err:
+            await client.head_bucket(Bucket="missing-bucket")
+
+    msg = err.value.args[0]
+    assert "HeadBucket operation" in msg
+    assert "403" in msg
+    assert "Forbidden" in msg
+
+
+@pytest.mark.skip("https://github.com/aio-libs/aiobotocore/issues/781")
+@pytest.mark.asyncio
+async def test_aio_s3_bucket_head_too_many_requests():
+
+    session = get_session()
+    aio_config = aiobotocore.config.AioConfig(max_pool_connections=1)
+    session.set_default_client_config(aio_config)
+    session.set_credentials("fake_AWS_ACCESS_KEY_ID", "fake_AWS_SECRET_ACCESS_KEY")
+
+    async with session.create_client("s3") as client:
+
+        # TODO: HOW TO ADD HTTP STUBBER HERE, similar to:
+        #   https://botocore.amazonaws.com/v1/documentation/api/latest/reference/stubber.html
+
+        with pytest.raises(botocore.exceptions.ClientError) as err:
+            await client.head_bucket(Bucket="missing-bucket")
+
+    msg = err.value.args[0]
+    assert "HeadBucket operation" in msg
+    assert "403" in msg
+    assert "Forbidden" in msg

--- a/tests/test_aiomoto_clients.py
+++ b/tests/test_aiomoto_clients.py
@@ -1,0 +1,175 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Asyncio AWS Client Fixtures
+
+This test suite checks fixtures for aiobotocore clients.
+
+Do _not_ use default moto mock decorators, which incur:
+AttributeError: 'AWSResponse' object has no attribute 'raw_headers'
+.. seealso:: https://github.com/aio-libs/aiobotocore/issues/755
+"""
+
+import os
+
+import pytest
+from aiobotocore.client import AioBaseClient
+from aiobotocore.session import AioSession
+
+from pytest_aiomoto.aiomoto_fixtures import AioAwsBatchClients
+from pytest_aiomoto.utils import AWS_ACCESS_KEY_ID
+from pytest_aiomoto.utils import AWS_REGION
+from pytest_aiomoto.utils import AWS_SECRET_ACCESS_KEY
+from pytest_aiomoto.utils import has_moto_mocks
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_session_credentials(aio_aws_session):
+    assert isinstance(aio_aws_session, AioSession)
+    credentials = await aio_aws_session.get_credentials()
+    assert credentials.access_key == AWS_ACCESS_KEY_ID
+    assert credentials.secret_key == AWS_SECRET_ACCESS_KEY
+    assert os.getenv("AWS_ACCESS_KEY_ID")
+    assert os.getenv("AWS_SECRET_ACCESS_KEY")
+    assert os.getenv("AWS_ACCESS_KEY_ID") == AWS_ACCESS_KEY_ID
+    assert os.getenv("AWS_SECRET_ACCESS_KEY") == AWS_SECRET_ACCESS_KEY
+
+
+def test_aio_aws_batch_clients(aio_aws_batch_clients):
+    clients = aio_aws_batch_clients
+    assert isinstance(clients, AioAwsBatchClients)
+    assert isinstance(clients.batch, AioBaseClient)
+    assert isinstance(clients.ec2, AioBaseClient)
+    assert isinstance(clients.ecs, AioBaseClient)
+    assert isinstance(clients.iam, AioBaseClient)
+    assert isinstance(clients.logs, AioBaseClient)
+    assert isinstance(clients.region, str)
+    assert clients.region == AWS_REGION
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_batch_client(aio_aws_batch_client):
+    client = aio_aws_batch_client
+    assert isinstance(client, AioBaseClient)
+
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = await client.describe_job_queues()
+    assert response_success(resp)
+    assert resp.get("jobQueues") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.batch.DescribeJobQueues")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_ec2_client(aio_aws_ec2_client):
+    client = aio_aws_ec2_client
+    assert isinstance(client, AioBaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = await client.describe_instances()
+    assert response_success(resp)
+    assert resp.get("Reservations") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.ec2.DescribeInstances")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_ecs_client(aio_aws_ecs_client):
+    client = aio_aws_ecs_client
+    assert isinstance(client, AioBaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = await client.list_task_definitions()
+    assert response_success(resp)
+    assert resp.get("taskDefinitionArns") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.ecs.ListTaskDefinitions")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_iam_client(aio_aws_iam_client):
+    client = aio_aws_iam_client
+    assert isinstance(client, AioBaseClient)
+    assert client.meta.config.region_name == "aws-global"  # not AWS_REGION
+    assert client.meta.region_name == "aws-global"  # not AWS_REGION
+
+    resp = await client.list_roles()
+    assert response_success(resp)
+    assert resp.get("Roles") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.iam.ListRoles")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_logs_client(aio_aws_logs_client):
+    client = aio_aws_logs_client
+    assert isinstance(client, AioBaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = await client.describe_log_groups()
+    assert response_success(resp)
+    assert resp.get("logGroups") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.cloudwatch-logs.DescribeLogGroups")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_s3_client(aio_aws_s3_client):
+    client = aio_aws_s3_client
+    assert isinstance(client, AioBaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = await client.list_buckets()
+    assert response_success(resp)
+    assert resp.get("Buckets") == []
+
+    # the event-name mocks are dynamically generated after calling the method;
+    # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+    assert not has_moto_mocks(client, "before-send.s3.ListBuckets")
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_client(aio_aws_client):
+    # aio_aws_client is an async generator
+    # aio_aws_client(service_name) yields a client
+    async for client in aio_aws_client("s3"):
+        assert isinstance(client, AioBaseClient)
+        assert client.meta.config.region_name == AWS_REGION
+        assert client.meta.region_name == AWS_REGION
+
+        resp = await client.list_buckets()
+        assert response_success(resp)
+        assert resp.get("Buckets") == []
+
+        # the event-name mocks are dynamically generated after calling the method;
+        # for aio-clients, they should be disabled for aiohttp to hit moto.server.
+        assert not has_moto_mocks(client, "before-send.s3.ListBuckets")

--- a/tests/test_aiomoto_cookiecutter.py
+++ b/tests/test_aiomoto_cookiecutter.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+# TODO: remove or adapt this module
+# https://docs.pytest.org/en/6.2.x/writing_plugins.html#testing-plugins
+
+
+@pytest.mark.skip
+def test_bar_fixture(testdir):
+    """Make sure that pytest accepts our fixture."""
+
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        def test_sth(bar):
+            assert bar == "europython2015"
+    """)
+
+    # run pytest with the following cmd args
+    result = testdir.runpytest(
+        '--foo=europython2015',
+        '-v'
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_sth PASSED*',
+    ])
+
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+@pytest.mark.skip
+def test_help_message(testdir):
+    result = testdir.runpytest(
+        '--help',
+    )
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        'aiomoto:',
+        '*--foo=DEST_FOO*Set the value for the fixture "bar".',
+    ])
+
+
+@pytest.mark.skip
+def test_hello_ini_setting(testdir):
+    testdir.makeini("""
+        [pytest]
+        HELLO = world
+    """)
+
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture
+        def hello(request):
+            return request.config.getini('HELLO')
+
+        def test_hello_world(hello):
+            assert hello == 'world'
+    """)
+
+    result = testdir.runpytest('-v')
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_hello_world PASSED*',
+    ])
+
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0

--- a/tests/test_aiomoto_service.py
+++ b/tests/test_aiomoto_service.py
@@ -1,0 +1,88 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test MotoService
+
+Test the aiohttp wrappers on moto.server, which run moto.server in a
+thread for each service (batch, s3, etc), using async/await wrappers
+to start and stop each server.
+"""
+import json
+
+import aiohttp
+import pytest
+
+from pytest_aiomoto.aiomoto_services import MotoService
+from pytest_aiomoto.utils import AWS_HOST
+
+
+def test_moto_service():
+    # this instantiates a MotoService but does not start a server
+    service = MotoService("s3")
+    assert AWS_HOST in service.endpoint_url
+    assert service._server is None
+
+
+@pytest.mark.asyncio
+async def test_moto_batch_service():
+    async with MotoService("batch") as batch_service:
+        assert batch_service._server  # __aenter__ starts a moto.server
+        assert batch_service._main_app
+        assert batch_service._main_app.app_instances["batch"]
+
+        batch_service.reset()  # clear all the backends
+
+        url = batch_service.endpoint_url + "/v1/describejobqueues"
+        batch_query = {"jobQueues": [], "maxResults": 10}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, data=batch_query, timeout=5) as resp:
+                assert resp.status == 200
+                job_queues = await resp.text()
+                job_queues = json.loads(job_queues)
+                assert job_queues["jobQueues"] == []
+
+
+@pytest.mark.asyncio
+async def test_moto_s3_service():
+    async with MotoService("s3") as s3_service:
+        assert s3_service._server  # __aenter__ starts a moto.server
+        assert s3_service._main_app
+        assert s3_service._main_app.app_instances["s3"]
+
+        s3_service.reset()  # clear all the backends
+
+        url = s3_service.endpoint_url
+        s3_xmlns = "http://s3.amazonaws.com/doc/2006-03-01"
+        async with aiohttp.ClientSession() as session:
+            # https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
+            async with session.get(url, timeout=5) as resp:
+                assert resp.status == 200
+                content = await resp.text()  # ListAllMyBucketsResult XML
+                assert s3_xmlns in content
+
+
+# This test is not necessary to run every time, but might be useful later.
+# @pytest.mark.asyncio
+# async def test_moto_api_service():
+#     # The moto-api is a flask UI to view moto backends
+#     async with MotoService("moto_api") as moto_api_service:
+#         assert moto_api_service._server  # __aenter__ starts a moto.server
+#
+#         url = moto_api_service.endpoint_url + "/moto-api"
+#         async with aiohttp.ClientSession() as session:
+#             async with session.get(url, timeout=5) as resp:
+#                 assert resp.status == 200
+#                 content = await resp.text()
+#                 assert content

--- a/tests/test_aws_batch.py
+++ b/tests/test_aws_batch.py
@@ -1,0 +1,127 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Asyncio AWS Batch
+
+This test suite uses a large suite of moto mocks for the AWS batch
+infrastructure. These infrastructure mocks are derived from the moto test
+suite for testing the batch client. The test infrastructure should be used
+according to the moto license (Apache-2.0).
+
+.. seealso::
+
+    - https://github.com/spulec/moto/pull/1197/files
+    - https://github.com/spulec/moto/blob/master/tests/test_batch/test_batch.py
+"""
+
+import pytest
+
+from pytest_aiomoto.utils import response_success
+from pytest_aiomoto.aws_fixtures import AwsBatchClients
+from pytest_aiomoto.aws_fixtures import AwsBatchInfrastructure
+from pytest_aiomoto.aws_fixtures import batch_infrastructure
+
+
+@pytest.fixture
+def aws_batch_infrastructure(
+    aws_batch_clients: AwsBatchClients,
+    compute_env_name: str,
+    job_queue_name: str,
+    job_definition_name: str,
+) -> AwsBatchInfrastructure:
+    aws_region = aws_batch_clients.region
+    aws_resources = batch_infrastructure(
+        aws_batch_clients, compute_env_name, job_queue_name, job_definition_name
+    )
+    return aws_resources
+
+
+def test_aws_batch_infrastructure(
+    aws_batch_infrastructure: AwsBatchInfrastructure,
+):
+    infrastructure = aws_batch_infrastructure
+    assert infrastructure
+    assert infrastructure.vpc_id
+    assert infrastructure.subnet_id
+    assert infrastructure.security_group_id
+    assert infrastructure.iam_arn
+    assert infrastructure.compute_env_name
+    assert infrastructure.compute_env_arn
+    assert infrastructure.job_queue_name
+    assert infrastructure.job_queue_arn
+    assert infrastructure.job_definition_name
+    assert infrastructure.job_definition_arn
+
+
+def test_batch_job_definitions(
+    aws_batch_infrastructure: AwsBatchInfrastructure,
+):
+    aws_resources = aws_batch_infrastructure
+    aws_region = aws_resources.aws_region
+    job_definition_name = aws_resources.job_definition_name
+
+    assert aws_resources
+    assert aws_resources.job_definition_arn
+    assert f"arn:aws:batch:{aws_region}" in aws_resources.job_definition_arn
+    assert job_definition_name in aws_resources.job_definition_arn
+
+    clients = aws_batch_infrastructure.aws_clients
+    response = clients.batch.describe_job_definitions()
+    assert response_success(response)
+    job_definitions = response["jobDefinitions"]
+    assert len(job_definitions) == 1
+    job_definition = job_definitions[0]
+    assert job_definition["jobDefinitionArn"] == aws_resources.job_definition_arn
+    assert job_definition["jobDefinitionName"] == aws_resources.job_definition_name
+
+
+def test_batch_job_queues(aws_batch_infrastructure: AwsBatchInfrastructure):
+    aws_resources = aws_batch_infrastructure
+    aws_region = aws_resources.aws_region
+    job_queue_name = aws_resources.job_queue_name
+
+    assert aws_resources
+    assert aws_resources.job_queue_arn
+    assert f"arn:aws:batch:{aws_region}" in aws_resources.job_queue_arn
+    assert job_queue_name in aws_resources.job_queue_arn
+
+    clients = aws_batch_infrastructure.aws_clients
+    response = clients.batch.describe_job_queues()
+    assert response_success(response)
+    job_queues = response["jobQueues"]
+    assert len(job_queues) == 1
+    job_queue = job_queues[0]
+    assert job_queue["jobQueueArn"] == aws_resources.job_queue_arn
+    assert job_queue["jobQueueName"] == aws_resources.job_queue_name
+
+
+def test_batch_list_jobs(aws_batch_infrastructure: AwsBatchInfrastructure):
+    clients = aws_batch_infrastructure.aws_clients
+    job_queue_name = aws_batch_infrastructure.job_queue_name
+
+    for job_status in [
+        "SUBMITTED",
+        "PENDING",
+        "RUNNABLE",
+        "STARTING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+    ]:
+        response = clients.batch.list_jobs(
+            jobQueue=job_queue_name, jobStatus=job_status
+        )
+        assert response_success(response)
+        assert response["jobSummaryList"] == []

--- a/tests/test_aws_fixtures.py
+++ b/tests/test_aws_fixtures.py
@@ -1,0 +1,133 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test AWS Fixtures
+
+This test suite checks fixtures for moto clients.
+
+"""
+
+import os
+
+from botocore.client import BaseClient
+
+from pytest_aiomoto.aws_fixtures import AWS_ACCESS_KEY_ID
+from pytest_aiomoto.aws_fixtures import AWS_REGION
+from pytest_aiomoto.aws_fixtures import AWS_SECRET_ACCESS_KEY
+from pytest_aiomoto.aws_fixtures import AwsBatchClients
+from pytest_aiomoto.aws_fixtures import has_moto_mocks
+from pytest_aiomoto.utils import response_success
+
+
+def test_aws_credentials(aws_credentials):
+    assert os.getenv("AWS_ACCESS_KEY_ID")
+    assert os.getenv("AWS_SECRET_ACCESS_KEY")
+    assert os.getenv("AWS_ACCESS_KEY_ID") == AWS_ACCESS_KEY_ID
+    assert os.getenv("AWS_SECRET_ACCESS_KEY") == AWS_SECRET_ACCESS_KEY
+
+
+def test_aws_clients(aws_batch_clients):
+    assert isinstance(aws_batch_clients, AwsBatchClients)
+    assert isinstance(aws_batch_clients.batch, BaseClient)
+    assert isinstance(aws_batch_clients.ec2, BaseClient)
+    assert isinstance(aws_batch_clients.ecs, BaseClient)
+    assert isinstance(aws_batch_clients.iam, BaseClient)
+    assert isinstance(aws_batch_clients.logs, BaseClient)
+    assert isinstance(aws_batch_clients.region, str)
+    assert aws_batch_clients.region == AWS_REGION
+
+
+def test_aws_batch_client(aws_batch_client):
+    client = aws_batch_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = client.describe_job_queues()
+    assert response_success(resp)
+    assert resp.get("jobQueues") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.batch.DescribeJobQueues")
+
+
+def test_aws_ec2_client(aws_ec2_client):
+    client = aws_ec2_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = client.describe_instances()
+    assert response_success(resp)
+    assert resp.get("Reservations") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.ec2.DescribeInstances")
+
+
+def test_aws_ecs_client(aws_ecs_client):
+    client = aws_ecs_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = client.list_task_definitions()
+    assert response_success(resp)
+    assert resp.get("taskDefinitionArns") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.ecs.ListTaskDefinitions")
+
+
+def test_aws_iam_client(aws_iam_client):
+    client = aws_iam_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == "aws-global"  # not AWS_REGION
+    assert client.meta.region_name == "aws-global"  # not AWS_REGION
+
+    resp = client.list_roles()
+    assert response_success(resp)
+    assert resp.get("Roles") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.iam.ListRoles")
+
+
+def test_aws_logs_client(aws_logs_client):
+    client = aws_logs_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = client.describe_log_groups()
+    assert response_success(resp)
+    assert resp.get("logGroups") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.cloudwatch-logs.DescribeLogGroups")
+
+
+def test_aws_s3_client(aws_s3_client):
+    client = aws_s3_client
+    assert isinstance(client, BaseClient)
+    assert client.meta.config.region_name == AWS_REGION
+    assert client.meta.region_name == AWS_REGION
+
+    resp = client.list_buckets()
+    assert response_success(resp)
+    assert resp.get("Buckets") == []
+
+    # the event-name mocks are dynamically generated after calling the method
+    assert has_moto_mocks(client, "before-send.s3.ListBuckets")

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -1,0 +1,47 @@
+from typing import Dict
+from typing import List
+
+import pytest
+
+from pytest_aiomoto.aws_lambda import aws_lambda_src
+from pytest_aiomoto.aws_lambda import aws_lambda_zip
+from pytest_aiomoto.aws_lambda import lambda_handler
+
+
+def test_lambda_handler_echo():
+    event = {"i": 0}
+    result = lambda_handler(event=event, context={})
+    assert isinstance(result, Dict)
+    assert result['statusCode'] == 200
+    body = result['body']
+    assert body == event
+
+
+def test_lambda_handler_too_large():
+    event = {"action": "too-large"}
+    result = lambda_handler(event=event, context={})
+    assert isinstance(result, Dict)
+    assert result['statusCode'] == 200
+    body = result['body']
+    assert body
+    assert isinstance(body, List)
+    assert isinstance(body[0], str)
+    assert body[0] == "xxx"
+    assert len(body) == 1000000
+
+
+def test_lambda_handler_raises():
+    event = {"action": "runtime-error"}
+    with pytest.raises(RuntimeError):
+        lambda_handler(event=event, context={})
+
+
+def test_aws_lambda_src():
+    lambda_src = aws_lambda_src()
+    assert isinstance(lambda_src, str)
+    assert 'def lambda_handler' in lambda_src
+
+
+def test_aws_lambda_zip():
+    lambda_zip = aws_lambda_zip()
+    assert isinstance(lambda_zip, bytes)

--- a/tests/test_aws_s3.py
+++ b/tests/test_aws_s3.py
@@ -1,0 +1,71 @@
+# Copyright 2019-2021 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from typing import List
+
+import pytest
+
+from pytest_aiomoto.utils import response_success
+
+
+@pytest.fixture
+def s3_bucket_name() -> str:
+    return "moto_bucket" + str(uuid.uuid4())
+
+
+@pytest.fixture
+def s3_bucket(s3_bucket_name, aws_s3_client, aws_region) -> str:
+    resp = aws_s3_client.create_bucket(
+        Bucket=s3_bucket_name,
+        ACL="public-read-write",
+        CreateBucketConfiguration={"LocationConstraint": aws_region},
+    )
+    assert response_success(resp)
+
+    # Ensure the bucket exists
+    exists_waiter = aws_s3_client.get_waiter("bucket_exists")
+    exists_waiter.wait(Bucket=s3_bucket_name)
+
+    head = aws_s3_client.head_bucket(Bucket=s3_bucket_name)
+    assert response_success(head)
+    return s3_bucket_name
+
+
+@pytest.fixture
+def s3_buckets(s3_bucket_name, aws_s3_client, aws_region) -> List[str]:
+    bucket_names = []
+    for i in range(20):
+        bucket_name = f"{s3_bucket_name}_{i:02d}"
+        resp = aws_s3_client.create_bucket(
+            Bucket=bucket_name,
+            ACL="public-read-write",
+            CreateBucketConfiguration={"LocationConstraint": aws_region},
+        )
+        assert response_success(resp)
+        # Ensure the bucket exists
+        exists_waiter = aws_s3_client.get_waiter("bucket_exists")
+        exists_waiter.wait(Bucket=bucket_name)
+
+        head = aws_s3_client.head_bucket(Bucket=bucket_name)
+        assert response_success(head)
+        bucket_names.append(bucket_name)
+    return bucket_names
+
+
+def test_s3_list_buckets(aws_s3_client, s3_buckets):
+    resp = aws_s3_client.list_buckets()
+    assert response_success(resp)
+    bucket_names = [b["Name"] for b in resp["Buckets"]]
+    assert bucket_names == s3_buckets


### PR DESCRIPTION
Add the pytest fixtures and plugin package.

This is an initial package based on the test suite from https://github.com/dazza-codes/aio-aws
- initial testing will replace many test fixtures from https://github.com/dazza-codes/aio-aws with this package
- this package is initially successful to the extent that aio-aws can use it without any changes to aio-aws, only removing some test fixtures that move to this package
