### PR TITLE
Make import of s3fs conditional in aws_credentials.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pytest-asyncio = "^0.21"
 # Allow updates to the latest s3fs/aiobotocore and moto
 # Allow s3fs/aiobotcore to bundle compatible versions of botocore, boto3, and awscli;
 # see https://github.com/fsspec/s3fs/blob/main/setup.py
-s3fs = {version = "^2023.0", extras = ["awscli", "boto3"]}
+s3fs = {version = "^2023.0", extras = ["awscli", "boto3"], optional = true }
 moto = {version = "^4.0", extras = ["all","server"]}
 
 aiofiles = "^22.0"
@@ -67,6 +67,8 @@ docs = [
     "mkdocs-material",
     "mkdocstrings",
 ]
+
+s3fs = ["s3fs"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pytest_aiomoto/aws_credentials.py
+++ b/pytest_aiomoto/aws_credentials.py
@@ -25,7 +25,6 @@ import boto3.session
 import botocore.session
 import pytest
 from botocore.exceptions import ProfileNotFound
-from s3fs import S3FileSystem
 
 from pytest_aiomoto.utils import AWS_ACCESS_KEY_ID
 from pytest_aiomoto.utils import AWS_REGION
@@ -75,7 +74,15 @@ def clean_aws_credentials(monkeypatch):
     # See https://github.com/dask/s3fs/issues/461 for details about
     # s3fs using an instance cache with stored credentials.
     boto3.DEFAULT_SESSION = None
-    S3FileSystem.clear_instance_cache()
+
+    try:
+        from s3fs import S3FileSystem
+    except ImportError:
+        # no s3fs, so nothing to clear
+        pass
+    else:
+        S3FileSystem.clear_instance_cache()
+
     monkeypatch.delenv("AWS_CONFIG_FILE", raising=False)
     monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
     monkeypatch.delenv("AWS_PROFILE", raising=False)


### PR DESCRIPTION
This PR adjusts the `aws_credentials.py` file to move the `from s3fs ...` import to be conditional: if the `s3fs` library doesn't exist, the code can still work fine, because the import is just to get an object that needs its cache cleared, and if there's no object, there's no need to clear anything. This PR also then restores the `s3fs` library to be optional (revising #26 and partially reverting #27).

Before this PR, the `from s3fs import ...` at the top level meant that the `s3fs` library had to be installed in order to import `aws_credentials.py`, which I think isn't the intention from the `aws_s3fs.py` code, which carefully guards the imports.

Having the dependency be optional is nice for us: fewer dependencies is better, and we're having trouble with s3fs and related libraries putting overly restrictive version ranges on dependencies like `aiobotocore`. So, if we don't need to depend on `s3fs` (because we don't use it), that'd be great. :)

Thanks for `pytest-aiomoto`, it's been handy for us. Let me know what you think!